### PR TITLE
HotFix that prevents the _remote_id from being overwritten if it already exists

### DIFF
--- a/condorpy/htcondor_object_base.py
+++ b/condorpy/htcondor_object_base.py
@@ -75,7 +75,8 @@ class HTCondorObjectBase(object):
             An RemoteClient representing the remote scheduler.
         """
         self._remote = RemoteClient(host, username, password, private_key, private_key_pass)
-        self._remote_id = uuid.uuid4().hex
+        if not self._remote_id:
+            self._remote_id = uuid.uuid4().hex
 
     @property
     def remote_input_files(self):


### PR DESCRIPTION
This was affecting Tethys Platform, because it was unable to return the files or check status for a job submitted to a remote scheduler due to the _remote_id changing everytime set_scheduler was called (which was frequent). Not sure if this is the best way to handle this.

Addresses issues related to #26.