### PR TITLE
Fixed issue caused by ssl warning in condor_q or condor_history outpu…

### DIFF
--- a/condorpy/workflow.py
+++ b/condorpy/workflow.py
@@ -140,12 +140,17 @@ class Workflow(HTCondorObjectBase):
             log.error('Error while updating status for job %s: Job not found.', job_id)
             raise HTCondorError('Job not found.')
 
-        out = out.replace('\"', '').strip()
+        out = out.replace('\"', '').split('\n')
         log.info('Job %s status: %s', job_id, out)
 
+        status_code = 0
         for status_code_str in out:
-            status_code = int(status_code_str)
-            key = CONDOR_JOB_STATUSES[status_code]
+            try:
+                status_code = int(status_code_str.strip())
+            except:
+                pass
+
+        key = CONDOR_JOB_STATUSES[status_code]
 
         return key
 

--- a/condorpy/workflow.py
+++ b/condorpy/workflow.py
@@ -141,7 +141,7 @@ class Workflow(HTCondorObjectBase):
             raise HTCondorError('Job not found.')
 
         out = out.replace('\"', '').split('\n')
-        log.info('Job %s status: %s', job_id, out)
+
 
         status_code = 0
         for status_code_str in out:
@@ -149,6 +149,8 @@ class Workflow(HTCondorObjectBase):
                 status_code = int(status_code_str.strip())
             except:
                 pass
+
+        log.info('Job %s status: %d', job_id, status_code)
 
         key = CONDOR_JOB_STATUSES[status_code]
 


### PR DESCRIPTION
…t, which would cause job table to fail to get updated status.

When the job table tried to update status it would get a string that looks something like this:

'4\ncondor_q: /usr/bin/../lib/libcrypto.so.1.0.0: no version information available (required by /usr/bin/../lib/libcondor_utils_8_4_9.so)\n\ncondor_history: /usr/bin/../lib/libcrypto.so.1.0.0: no version information available (required by /usr/bin/../lib/libcondor_utils_8_4_9.so)\n'

The current implementation would fail on the second character (\n) when it tried to convert it to an int. The solution was to split on newlines and put a try except around the int which would pass on the warning messages.